### PR TITLE
Add ZMQ-based remote FFmpeg service and configuration

### DIFF
--- a/apple_silicon_ffmpeg/service.py
+++ b/apple_silicon_ffmpeg/service.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Remote FFmpeg service for Apple Silicon.
+
+This simple service exposes a ZMQ REP socket that accepts a multipart
+message of [header_json, payload]. The header defines the ffmpeg command
+arguments and the payload contains raw video or audio data which will be
+fed to ffmpeg's stdin. The stdout of ffmpeg is returned as the reply.
+
+The service always prepends `-hwaccel videotoolbox` to the ffmpeg command
+to leverage Apple Silicon hardware acceleration.
+"""
+import argparse
+import json
+import subprocess as sp
+from typing import List
+
+import zmq
+
+
+def run_ffmpeg(cmd: List[str], buffer: bytes) -> bytes:
+    """Run ffmpeg with the provided command and input buffer."""
+    full_cmd = ["ffmpeg", "-hwaccel", "videotoolbox"] + cmd
+    process = sp.Popen(
+        full_cmd,
+        stdin=sp.PIPE,
+        stdout=sp.PIPE,
+        stderr=sp.PIPE,
+    )
+    out, _ = process.communicate(buffer)
+    return out
+
+
+def serve(endpoint: str) -> None:
+    context = zmq.Context()
+    socket = context.socket(zmq.REP)
+    socket.bind(endpoint)
+    while True:
+        frames = socket.recv_multipart()
+        if not frames:
+            socket.send(b"")
+            continue
+        header = json.loads(frames[0].decode("utf-8"))
+        payload = frames[1] if len(frames) > 1 else b""
+        cmd = header.get("cmd", [])
+        try:
+            result = run_ffmpeg(cmd, payload)
+        except Exception as exc:  # noqa: BLE001
+            result = str(exc).encode("utf-8")
+        socket.send(result)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Apple Silicon FFmpeg service")
+    parser.add_argument("--bind", default="tcp://*:5555", help="ZMQ bind endpoint")
+    args = parser.parse_args()
+    serve(args.bind)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/docs/configuration/hardware_acceleration_video.md
+++ b/docs/docs/configuration/hardware_acceleration_video.md
@@ -9,6 +9,30 @@ It is highly recommended to use a GPU for hardware acceleration video decoding i
 
 Depending on your system, these parameters may not be compatible. More information on hardware accelerated decoding for ffmpeg can be found here: https://trac.ffmpeg.org/wiki/HWAccelIntro
 
+## Apple Silicon via Remote FFmpeg
+
+Frigate can use a separate FFmpeg service to leverage Apple Silicon's `videotoolbox` hardware acceleration. The service communicates over ZMQ and runs on the host system.
+
+1. Start the service:
+
+```bash
+python apple_silicon_ffmpeg/service.py --bind tcp://0.0.0.0:5555
+```
+
+2. Configure a camera to use the remote service:
+
+```yaml
+cameras:
+  cam1:
+    ffmpeg:
+      mode: zmq
+      endpoint: tcp://localhost:5555
+      inputs:
+        - path: rtsp://camera/stream
+          roles: [detect]
+```
+
+When `mode` is set to `zmq`, Frigate sends commands and receives frames over the specified `endpoint` instead of spawning a local FFmpeg process.
 
 ## Raspberry Pi 3/4
 

--- a/frigate/config/camera/ffmpeg.py
+++ b/frigate/config/camera/ffmpeg.py
@@ -2,6 +2,7 @@ from enum import Enum
 from typing import Union
 
 from pydantic import Field, field_validator
+from typing_extensions import Literal
 
 from frigate.const import DEFAULT_FFMPEG_VERSION, INCLUDED_FFMPEG_VERSIONS
 
@@ -66,6 +67,12 @@ class FfmpegConfig(FrigateBaseModel):
     apple_compatibility: bool = Field(
         default=False,
         title="Set tag on HEVC (H.265) recording stream to improve compatibility with Apple players.",
+    )
+    mode: Literal["local", "zmq"] = Field(
+        default="local", title="FFmpeg execution mode."
+    )
+    endpoint: str | None = Field(
+        default=None, title="ZMQ endpoint for remote FFmpeg service."
     )
 
     @property

--- a/frigate/ffmpeg/zmq.py
+++ b/frigate/ffmpeg/zmq.py
@@ -1,0 +1,135 @@
+"""ZMQ-based remote FFmpeg client utilities."""
+from __future__ import annotations
+
+import logging
+import subprocess as sp
+from typing import Any, List
+
+import zmq
+
+from frigate.log import LogPipe
+
+
+class ZmqRemoteFfmpegClient:
+    def __init__(
+        self,
+        endpoint: str,
+        cmd: List[str],
+        request_timeout_ms: int = 1000,
+        linger_ms: int = 0,
+    ) -> None:
+        self._context = zmq.Context()
+        self._endpoint = endpoint
+        self._request_timeout_ms = request_timeout_ms
+        self._linger_ms = linger_ms
+        self._socket = None
+        self._create_socket()
+        self._cmd = cmd
+        self.pid = 0
+        self._start()
+
+    def _create_socket(self) -> None:
+        if self._socket is not None:
+            try:
+                self._socket.close(linger=self._linger_ms)
+            except Exception:  # noqa: BLE001
+                pass
+        self._socket = self._context.socket(zmq.REQ)
+        self._socket.setsockopt(zmq.RCVTIMEO, self._request_timeout_ms)
+        self._socket.setsockopt(zmq.SNDTIMEO, self._request_timeout_ms)
+        self._socket.setsockopt(zmq.LINGER, self._linger_ms)
+        self._socket.connect(self._endpoint)
+
+    def _start(self) -> None:
+        try:
+            self._socket.send_json({"cmd": self._cmd})
+            self._socket.recv()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def read(self, size: int) -> bytes:
+        try:
+            self._socket.send(b"frame")
+            return self._socket.recv()
+        except zmq.Again:
+            try:
+                self._create_socket()
+            except Exception:  # noqa: BLE001
+                pass
+            return b""
+        except zmq.ZMQError:
+            try:
+                self._create_socket()
+            except Exception:  # noqa: BLE001
+                pass
+            return b""
+
+    def terminate(self) -> None:
+        self.close()
+
+    def close(self) -> None:
+        try:
+            self._socket.send(b"stop")
+            self._socket.recv()
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            self._socket.close(linger=self._linger_ms)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def poll(self) -> None:
+        return None
+
+
+def stop_ffmpeg(ffmpeg_process, logger: logging.Logger) -> None:
+    if hasattr(ffmpeg_process, "close") and not isinstance(ffmpeg_process, sp.Popen):
+        logger.info("Closing the existing ffmpeg client...")
+        ffmpeg_process.close()
+        return
+    logger.info("Terminating the existing ffmpeg process...")
+    ffmpeg_process.terminate()
+    try:
+        logger.info("Waiting for ffmpeg to exit gracefully...")
+        ffmpeg_process.communicate(timeout=30)
+    except sp.TimeoutExpired:
+        logger.info("FFmpeg didn't exit. Force killing...")
+        ffmpeg_process.kill()
+        ffmpeg_process.communicate()
+
+
+def start_or_restart_ffmpeg(
+    ffmpeg_cmd: List[str],
+    logger: logging.Logger,
+    logpipe: LogPipe,
+    frame_size: int | None = None,
+    ffmpeg_process: Any = None,
+    mode: str = "local",
+    zmq_endpoint: str | None = None,
+):
+    if mode == "zmq" and zmq_endpoint:
+        if ffmpeg_process is not None and hasattr(ffmpeg_process, "close"):
+            ffmpeg_process.close()
+        return ZmqRemoteFfmpegClient(zmq_endpoint, ffmpeg_cmd)
+
+    if ffmpeg_process is not None:
+        stop_ffmpeg(ffmpeg_process, logger)
+
+    if frame_size is None:
+        process = sp.Popen(
+            ffmpeg_cmd,
+            stdout=sp.DEVNULL,
+            stderr=logpipe,
+            stdin=sp.DEVNULL,
+            start_new_session=True,
+        )
+    else:
+        process = sp.Popen(
+            ffmpeg_cmd,
+            stdout=sp.PIPE,
+            stderr=logpipe,
+            stdin=sp.DEVNULL,
+            bufsize=frame_size * 10,
+            start_new_session=True,
+        )
+    return process

--- a/frigate/test/test_ffmpeg_zmq.py
+++ b/frigate/test/test_ffmpeg_zmq.py
@@ -1,0 +1,55 @@
+import json
+import logging
+import threading
+import time
+
+import zmq
+
+from frigate.ffmpeg.zmq import start_or_restart_ffmpeg, stop_ffmpeg
+from frigate.log import LogPipe
+
+
+def _mock_server(endpoint: str, frame: bytes) -> None:
+    context = zmq.Context()
+    socket = context.socket(zmq.REP)
+    socket.bind(endpoint)
+    try:
+        while True:
+            msg = socket.recv()
+            try:
+                json.loads(msg.decode("utf-8"))
+                socket.send(b"ok")
+                continue
+            except Exception:
+                pass
+            if msg == b"frame":
+                socket.send(frame)
+            elif msg == b"stop":
+                socket.send(b"bye")
+                break
+            else:
+                socket.send(b"")
+    finally:
+        socket.close()
+        context.term()
+
+
+def test_zmq_ffmpeg_client() -> None:
+    endpoint = "tcp://127.0.0.1:5560"
+    frame = b"abcd"
+    t = threading.Thread(target=_mock_server, args=(endpoint, frame), daemon=True)
+    t.start()
+    time.sleep(0.1)
+    logpipe = LogPipe("test")
+    client = start_or_restart_ffmpeg(
+        ["dummy"],
+        logging.getLogger("test"),
+        logpipe,
+        frame_size=4,
+        mode="zmq",
+        zmq_endpoint=endpoint,
+    )
+    data = client.read(4)
+    assert data == frame
+    stop_ffmpeg(client, logging.getLogger("test"))
+    logpipe.close()

--- a/frigate/video.py
+++ b/frigate/video.py
@@ -25,6 +25,7 @@ from frigate.const import (
     PROCESS_PRIORITY_HIGH,
     REQUEST_REGION_GRID,
 )
+from frigate.ffmpeg.zmq import start_or_restart_ffmpeg, stop_ffmpeg
 from frigate.log import LogPipe
 from frigate.motion import MotionDetector
 from frigate.motion.improved_motion import ImprovedMotionDetector
@@ -55,48 +56,8 @@ from frigate.util.process import FrigateProcess
 
 logger = logging.getLogger(__name__)
 
-
-def stop_ffmpeg(ffmpeg_process: sp.Popen[Any], logger: logging.Logger):
-    logger.info("Terminating the existing ffmpeg process...")
-    ffmpeg_process.terminate()
-    try:
-        logger.info("Waiting for ffmpeg to exit gracefully...")
-        ffmpeg_process.communicate(timeout=30)
-    except sp.TimeoutExpired:
-        logger.info("FFmpeg didn't exit. Force killing...")
-        ffmpeg_process.kill()
-        ffmpeg_process.communicate()
-    ffmpeg_process = None
-
-
-def start_or_restart_ffmpeg(
-    ffmpeg_cmd, logger, logpipe: LogPipe, frame_size=None, ffmpeg_process=None
-) -> sp.Popen[Any]:
-    if ffmpeg_process is not None:
-        stop_ffmpeg(ffmpeg_process, logger)
-
-    if frame_size is None:
-        process = sp.Popen(
-            ffmpeg_cmd,
-            stdout=sp.DEVNULL,
-            stderr=logpipe,
-            stdin=sp.DEVNULL,
-            start_new_session=True,
-        )
-    else:
-        process = sp.Popen(
-            ffmpeg_cmd,
-            stdout=sp.PIPE,
-            stderr=logpipe,
-            stdin=sp.DEVNULL,
-            bufsize=frame_size * 10,
-            start_new_session=True,
-        )
-    return process
-
-
 def capture_frames(
-    ffmpeg_process: sp.Popen[Any],
+    ffmpeg_process,
     config: CameraConfig,
     shm_frame_count: int,
     frame_index: int,
@@ -133,7 +94,10 @@ def capture_frames(
         frame_name = f"{config.name}_frame{frame_index}"
         frame_buffer = frame_manager.write(frame_name)
         try:
-            frame_buffer[:] = ffmpeg_process.stdout.read(frame_size)
+            if hasattr(ffmpeg_process, "read") and not hasattr(ffmpeg_process, "stdout"):
+                frame_buffer[:] = ffmpeg_process.read(frame_size)
+            else:
+                frame_buffer[:] = ffmpeg_process.stdout.read(frame_size)
         except Exception:
             # shutdown has been initiated
             if stop_event.is_set():
@@ -141,7 +105,7 @@ def capture_frames(
 
             logger.error(f"{config.name}: Unable to read frames from ffmpeg process.")
 
-            if ffmpeg_process.poll() is not None:
+            if hasattr(ffmpeg_process, "poll") and ffmpeg_process.poll() is not None:
                 logger.error(
                     f"{config.name}: ffmpeg process is not running. exiting capture thread..."
                 )
@@ -316,6 +280,8 @@ class CameraWatchdog(threading.Thread):
                             self.logger,
                             p["logpipe"],
                             ffmpeg_process=p["process"],
+                            mode=self.config.ffmpeg.mode,
+                            zmq_endpoint=self.config.ffmpeg.endpoint,
                         )
 
                         for role in p["roles"]:
@@ -340,7 +306,12 @@ class CameraWatchdog(threading.Thread):
 
                 p["logpipe"].dump()
                 p["process"] = start_or_restart_ffmpeg(
-                    p["cmd"], self.logger, p["logpipe"], ffmpeg_process=p["process"]
+                    p["cmd"],
+                    self.logger,
+                    p["logpipe"],
+                    ffmpeg_process=p["process"],
+                    mode=self.config.ffmpeg.mode,
+                    zmq_endpoint=self.config.ffmpeg.endpoint,
                 )
 
         self.stop_all_ffmpeg()
@@ -352,9 +323,14 @@ class CameraWatchdog(threading.Thread):
             c["cmd"] for c in self.config.ffmpeg_cmds if "detect" in c["roles"]
         ][0]
         self.ffmpeg_detect_process = start_or_restart_ffmpeg(
-            ffmpeg_cmd, self.logger, self.logpipe, self.frame_size
+            ffmpeg_cmd,
+            self.logger,
+            self.logpipe,
+            self.frame_size,
+            mode=self.config.ffmpeg.mode,
+            zmq_endpoint=self.config.ffmpeg.endpoint,
         )
-        self.ffmpeg_pid.value = self.ffmpeg_detect_process.pid
+        self.ffmpeg_pid.value = getattr(self.ffmpeg_detect_process, "pid", 0)
         self.capture_thread = CameraCaptureRunner(
             self.config,
             self.shm_frame_count,
@@ -383,7 +359,13 @@ class CameraWatchdog(threading.Thread):
                     "cmd": c["cmd"],
                     "roles": c["roles"],
                     "logpipe": logpipe,
-                    "process": start_or_restart_ffmpeg(c["cmd"], self.logger, logpipe),
+                    "process": start_or_restart_ffmpeg(
+                        c["cmd"],
+                        self.logger,
+                        logpipe,
+                        mode=self.config.ffmpeg.mode,
+                        zmq_endpoint=self.config.ffmpeg.endpoint,
+                    ),
                 }
             )
 


### PR DESCRIPTION
## Summary
- add Apple Silicon FFmpeg service exposing a ZMQ REP endpoint
- allow cameras to use remote ffmpeg via `mode: zmq` and `endpoint`
- send frames/commands over ZMQ when configured and provide tests

## Testing
- `ruff check frigate/config/camera/ffmpeg.py frigate/video.py apple_silicon_ffmpeg/service.py frigate/test/test_ffmpeg_zmq.py` (passed)
- `pytest frigate/test/test_ffmpeg_zmq.py` (passed)
- `pytest frigate/test/test_video.py` (missing dependency: peewee)


------
https://chatgpt.com/codex/tasks/task_e_68c1283ef524832990027b599bceb5f8