### PR TITLE
feat(proxy): relay to host services over TCP

### DIFF
--- a/docs/docs/configuration/host_services.md
+++ b/docs/docs/configuration/host_services.md
@@ -1,0 +1,34 @@
+---
+id: host_services
+title: Host Services
+---
+
+Frigate normally uses a ZeroMQ (ZMQ) proxy to move messages between its
+internal processes. The proxy can also relay messages to services running on
+the Docker host. This allows external detectors, audio transcription engines,
+or embedding generators to subscribe and publish data without running inside
+the container.
+
+Set the following environment variables when starting the container:
+
+```
+FRIGATE_PROXY_HOST_PUB=tcp://host.docker.internal:5556
+FRIGATE_PROXY_HOST_SUB=tcp://host.docker.internal:5557
+FRIGATE_PROXY_TIMEOUT_MS=1000  # optional, defaults to 1000ms
+```
+
+`FRIGATE_PROXY_HOST_PUB` should point to a PUB socket on the host that sends
+messages into Frigate. `FRIGATE_PROXY_HOST_SUB` is the SUB socket on the host
+that receives messages published by Frigate. The timeout variable controls how
+long the proxy waits when connecting to the host before giving up.
+
+:::note
+The host service must bind to the referenced ports and the container must be
+able to reach them. On Linux hosts running `ufw` or `firewalld`, you may need
+to open the ports to allow the container to connect.
+:::
+
+With the proxy bridge enabled, host services can participate in Frigate's
+messaging topics for detection, transcription, and embeddings without blocking
+Frigate when the host service is unavailable.
+

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -85,6 +85,7 @@ const sidebars: SidebarsConfig = {
         "configuration/pwa",
         "configuration/tls",
         "configuration/advanced",
+        "configuration/host_services",
       ],
     },
     Integrations: [

--- a/frigate/comms/zmq_proxy.py
+++ b/frigate/comms/zmq_proxy.py
@@ -1,28 +1,60 @@
 """Facilitates communication over zmq proxy."""
 
 import json
+import os
+import socket
 import threading
 from typing import Generic, TypeVar
 
 import zmq
+import logging
 
 from frigate.const import FAST_QUEUE_TIMEOUT
 
 SOCKET_PUB = "ipc:///tmp/cache/proxy_pub"
 SOCKET_SUB = "ipc:///tmp/cache/proxy_sub"
 
+HOST_SOCKET_PUB = os.getenv("FRIGATE_PROXY_HOST_PUB")
+HOST_SOCKET_SUB = os.getenv("FRIGATE_PROXY_HOST_SUB")
+# timeout (ms) used for host health checks and connects
+HOST_CONNECT_TIMEOUT = int(os.getenv("FRIGATE_PROXY_TIMEOUT_MS", "1000"))
+
 
 class ZmqProxyRunner(threading.Thread):
-    def __init__(self, context: zmq.Context[zmq.Socket]) -> None:
+    def __init__(
+        self,
+        context: zmq.Context[zmq.Socket],
+        host_pub: str | None,
+        host_sub: str | None,
+        timeout_ms: int,
+    ) -> None:
         super().__init__(name="detection_proxy")
         self.context = context
+        self.host_pub = host_pub
+        self.host_sub = host_sub
+        self.timeout_ms = timeout_ms
 
     def run(self) -> None:
         """Run the proxy."""
         incoming = self.context.socket(zmq.XSUB)
         incoming.bind(SOCKET_PUB)
+        incoming.setsockopt(zmq.LINGER, 0)
+        if self.host_pub:
+            incoming.setsockopt(zmq.CONNECT_TIMEOUT, self.timeout_ms)
+            try:
+                incoming.connect(self.host_pub)
+            except zmq.ZMQError:
+                pass
+
         outgoing = self.context.socket(zmq.XPUB)
         outgoing.bind(SOCKET_SUB)
+        outgoing.setsockopt(zmq.LINGER, 0)
+        if self.host_sub:
+            outgoing.setsockopt(zmq.CONNECT_TIMEOUT, self.timeout_ms)
+            try:
+                outgoing.connect(self.host_sub)
+            except zmq.ZMQError:
+                pass
 
         # Blocking: This will unblock (via exception) when we destroy the context
         # The incoming and outgoing sockets will be closed automatically
@@ -37,8 +69,31 @@ class ZmqProxy:
     """Proxies video and audio detections."""
 
     def __init__(self) -> None:
+        host_pub = HOST_SOCKET_PUB
+        host_sub = HOST_SOCKET_SUB
+        timeout_ms = HOST_CONNECT_TIMEOUT
+
+        # basic health check so a missing host service doesn't block startup
+        for endpoint in [host_pub, host_sub]:
+            if endpoint and endpoint.startswith("tcp://"):
+                address, port = endpoint[6:].rsplit(":", 1)
+                try:
+                    with socket.create_connection(
+                        (address, int(port)), timeout=timeout_ms / 1000
+                    ):
+                        pass
+                except OSError:
+                    # log a warning and disable host proxying for this endpoint
+                    logging.warning(
+                        "Host ZMQ endpoint %s unreachable; continuing without it", endpoint
+                    )
+                    if endpoint == host_pub:
+                        host_pub = None
+                    else:
+                        host_sub = None
+
         self.context = zmq.Context()
-        self.runner = ZmqProxyRunner(self.context)
+        self.runner = ZmqProxyRunner(self.context, host_pub, host_sub, timeout_ms)
         self.runner.start()
 
     def stop(self) -> None:


### PR DESCRIPTION
## Summary
- allow ZMQ proxy to bridge container messages to host services via configurable TCP endpoints
- add connection timeouts and simple health check to avoid blocking when host service is down
- document host service environment variables and firewall requirements

## Testing
- `python -m unittest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `python -m mypy --config-file frigate/mypy.ini frigate` *(fails: Found 38 errors)*
- `python -m ruff check frigate/comms/zmq_proxy.py docs/sidebars.ts docs/docs/configuration/host_services.md`

------
https://chatgpt.com/codex/tasks/task_e_68c126d395408329882d8ac4209d8353