### PR TITLE
Add ZMQ-based remote audio transcription

### DIFF
--- a/apple-silicon-transcriber/README.md
+++ b/apple-silicon-transcriber/README.md
@@ -1,0 +1,18 @@
+# Apple Silicon Transcriber
+
+A lightweight transcription server for Apple Silicon hosts. The service loads a
+Whisper or sherpa-onnx model using `onnxruntime` with the
+`CoreMLExecutionProvider` and exposes a simple ZeroMQ REP endpoint.
+
+## Usage
+
+```bash
+python server.py --model /path/to/model.onnx --bind tcp://*:5557
+```
+
+Requests should be sent as a multipart message containing a JSON header and raw
+PCM audio bytes. The server responds with the transcription text.
+
+This project mirrors the architecture of the
+[apple-silicon-detector](https://github.com/frigate-nvr/apple-silicon-detector)
+used for object detection.

--- a/apple-silicon-transcriber/server.py
+++ b/apple-silicon-transcriber/server.py
@@ -1,0 +1,64 @@
+import argparse
+import json
+from typing import Any
+
+import numpy as np
+import onnxruntime as ort
+import zmq
+
+
+# Simple ZMQ based transcription service for Apple Silicon machines.
+#
+# The server loads an ONNX model (Whisper or sherpa-onnx) using the
+# CoreMLExecutionProvider to leverage the Apple Neural Engine. Requests are
+# handled over a ZMQ REP socket. Each request is a multipart message containing
+# a JSON header followed by raw PCM bytes. The server returns the transcription
+# text as a UTF-8 string.
+
+
+def load_session(model_path: str) -> ort.InferenceSession:
+    """Load an ONNX model with CoreML and CPU providers."""
+    return ort.InferenceSession(
+        model_path,
+        providers=["CoreMLExecutionProvider", "CPUExecutionProvider"],
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Apple Silicon transcription server")
+    parser.add_argument("--model", required=True, help="Path to ONNX model")
+    parser.add_argument(
+        "--bind",
+        default="tcp://*:5557",
+        help="ZMQ bind endpoint, e.g. tcp://*:5557",
+    )
+    args = parser.parse_args()
+
+    session = load_session(args.model)
+
+    context = zmq.Context()
+    socket = context.socket(zmq.REP)
+    socket.bind(args.bind)
+
+    input_name = session.get_inputs()[0].name
+
+    while True:
+        header_bytes, audio_bytes = socket.recv_multipart()
+        header = json.loads(header_bytes.decode("utf-8"))
+        dtype = np.dtype(header.get("dtype", "float32"))
+        shape = header.get("shape", (-1,))
+        audio = np.frombuffer(audio_bytes, dtype=dtype).reshape(shape)
+
+        outputs = session.run(None, {input_name: audio})
+        # Assume first output represents transcription tokens or string
+        text: Any = outputs[0]
+        if isinstance(text, bytes):
+            result = text.decode("utf-8")
+        else:
+            result = str(text)
+
+        socket.send_string(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/docs/configuration/audio_detectors.md
+++ b/docs/docs/configuration/audio_detectors.md
@@ -107,7 +107,7 @@ The optional config parameters that can be set at the global level include:
   - It is recommended to only configure the features at the global level, and enable it at the individual camera level.
 - **`device`**: Device to use to run transcription and translation models.
   - Default: `CPU`
-  - This can be `CPU` or `GPU`. The `sherpa-onnx` models are lightweight and run on the CPU only. The `whisper` models can run on GPU but are only supported on CUDA hardware.
+  - This can be `CPU`, `GPU`, or `zmq`. The `sherpa-onnx` models are lightweight and run on the CPU only. The `whisper` models can run on GPU but are only supported on CUDA hardware. Set this to `zmq` to forward audio to an external transcription service such as the Apple Silicon transcriber.
 - **`model_size`**: The size of the model used for live transcription.
   - Default: `small`
   - This can be `small` or `large`. The `small` setting uses `sherpa-onnx` models that are fast, lightweight, and always run on the CPU but are not as accurate as the `whisper` model.
@@ -118,8 +118,23 @@ The optional config parameters that can be set at the global level include:
   - You must use a valid [language code](https://github.com/openai/whisper/blob/main/whisper/tokenizer.py#L10).
   - Transcriptions for `speech` events are translated.
   - Live audio is translated only if you are using the `large` model. The `small` `sherpa-onnx` model is English-only.
+- **`endpoint`**: ZMQ endpoint of a remote transcription service when `device` is set to `zmq`.
 
-The only field that is valid at the camera level is `enabled`.
+The fields that are valid at the camera level are `enabled`, `live_enabled`, `device`, and `endpoint`.
+
+Example configuration using a remote Apple Silicon transcriber:
+
+```yaml
+audio_transcription:
+  enabled: true
+  device: zmq
+  endpoint: tcp://host.docker.internal:5557
+
+cameras:
+  back_yard:
+    audio_transcription:
+      enabled: true
+```
 
 #### Live transcription
 

--- a/docs/docs/frigate/hardware.md
+++ b/docs/docs/frigate/hardware.md
@@ -194,6 +194,11 @@ Apple Silicon can not run within a container, so a ZMQ proxy is utilized to comm
 
 :::
 
+An Apple Silicon host may also be used for audio transcription by running the
+[apple-silicon-transcriber](https://github.com/frigate-nvr/apple-silicon-transcriber)
+service on the host OS. Configure Frigate with `audio_transcription.device: zmq`
+and provide the service's `endpoint` to offload transcription to the NPU.
+
 | Name      | YOLOv9 Inference Time  |
 | --------- | ---------------------- |
 | M3 Pro    | t-320: 6 ms s-320: 8ms |

--- a/frigate/config/classification.py
+++ b/frigate/config/classification.py
@@ -23,6 +23,7 @@ class SemanticSearchModelEnum(str, Enum):
 class EnrichmentsDeviceEnum(str, Enum):
     GPU = "GPU"
     CPU = "CPU"
+    ZMQ = "zmq"
 
 
 class TriggerType(str, Enum):
@@ -57,6 +58,10 @@ class AudioTranscriptionConfig(FrigateBaseModel):
     )
     live_enabled: Optional[bool] = Field(
         default=False, title="Enable live transcriptions."
+    )
+    endpoint: str | None = Field(
+        default=None,
+        title="ZMQ endpoint for remote audio transcription when device is 'zmq'.",
     )
 
 

--- a/frigate/config/config.py
+++ b/frigate/config/config.py
@@ -513,7 +513,7 @@ class FrigateConfig(FrigateBaseModel):
             allowed_fields_map = {
                 "face_recognition": ["enabled", "min_area"],
                 "lpr": ["enabled", "expire_time", "min_area", "enhancement"],
-                "audio_transcription": ["enabled", "live_enabled"],
+                "audio_transcription": ["enabled", "live_enabled", "device", "endpoint"],
             }
 
             for section in allowed_fields_map:

--- a/frigate/data_processing/common/audio_transcription/model.py
+++ b/frigate/data_processing/common/audio_transcription/model.py
@@ -1,9 +1,12 @@
 """Set up audio transcription models based on model size."""
 
+import json
 import logging
 import os
 
+import numpy as np
 import sherpa_onnx
+import zmq
 from faster_whisper.utils import download_model
 
 from frigate.comms.inter_process import InterProcessRequestor
@@ -22,6 +25,13 @@ class AudioTranscriptionModelRunner:
     ):
         self.model: AudioTranscriptionModel = None
         self.requestor = InterProcessRequestor()
+        self.device = device
+
+        if device == "zmq":
+            # Initialize ZMQ context for remote transcription
+            self._zmq_context = zmq.Context()
+            self._sockets: dict[str, zmq.Socket] = {}
+            return
 
         if model_size == "large":
             # use the Whisper download function instead of our own
@@ -79,3 +89,28 @@ class AudioTranscriptionModelRunner:
             ModelDownloader.download_from_url(self.model_files[file_name], path)
         except Exception as e:
             logger.error(f"Failed to download {path}: {e}")
+
+    def transcribe_zmq(self, audio: np.ndarray, endpoint: str) -> str | None:
+        """Forward audio to a remote transcription service over ZMQ."""
+        if self.device != "zmq":
+            return None
+
+        socket = self._sockets.get(endpoint)
+        if socket is None:
+            socket = self._zmq_context.socket(zmq.REQ)
+            socket.connect(endpoint)
+            self._sockets[endpoint] = socket
+
+        header = {
+            "shape": list(audio.shape),
+            "dtype": str(audio.dtype.name),
+        }
+
+        try:
+            socket.send_multipart(
+                [json.dumps(header).encode("utf-8"), memoryview(audio.tobytes())]
+            )
+            return socket.recv_string()
+        except Exception as e:
+            logger.error(f"ZMQ transcription failed: {e}")
+            return None

--- a/frigate/data_processing/real_time/audio_transcription.py
+++ b/frigate/data_processing/real_time/audio_transcription.py
@@ -78,6 +78,24 @@ class AudioTranscriptionRealTimeProcessor(RealTimeProcessorApi):
     def __process_audio_stream(
         self, audio_data: np.ndarray
     ) -> Optional[tuple[str, bool]]:
+        if self.config.audio_transcription.device == "zmq":
+            endpoint = (
+                self.camera_config.audio_transcription.endpoint
+                or self.config.audio_transcription.endpoint
+            )
+
+            if not endpoint:
+                logger.error(
+                    "Audio transcription endpoint must be configured when device is 'zmq'"
+                )
+                return None
+
+            text = self.model_runner.transcribe_zmq(audio_data, endpoint)
+            if not text:
+                logger.debug("No transcription returned from remote service")
+                return None
+            return text.strip(), True
+
         if (
             self.model_runner.model is None
             and self.config.audio_transcription.model_size == "small"
@@ -184,7 +202,7 @@ class AudioTranscriptionRealTimeProcessor(RealTimeProcessorApi):
 
                 self.audio_queue.task_done()
 
-                if is_endpoint:
+                if is_endpoint and self.config.audio_transcription.device != "zmq":
                     self.reset()
 
             except queue.Empty:

--- a/web/src/types/frigateConfig.ts
+++ b/web/src/types/frigateConfig.ts
@@ -47,6 +47,8 @@ export interface CameraConfig {
     enabled: boolean;
     enabled_in_config: boolean;
     live_enabled: boolean;
+    device?: "CPU" | "GPU" | "zmq";
+    endpoint?: string | null;
   };
   best_image_timeout: number;
   birdseye: {
@@ -340,6 +342,10 @@ export interface FrigateConfig {
 
   audio_transcription: {
     enabled: boolean;
+    device: "CPU" | "GPU" | "zmq";
+    model_size: "small" | "large";
+    language: string;
+    endpoint?: string | null;
   };
 
   birdseye: BirdseyeConfig;


### PR DESCRIPTION
## Summary
- add apple-silicon-transcriber service using CoreML and ZMQ
- allow `audio_transcription.device: zmq` with remote endpoint
- forward audio buffers to remote ZMQ service for live transcription

## Testing
- `pytest` *(fails: Interrupted: 19 errors during collection)*
- `npm test -- --run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68c126ce27588329a377c72a6e883c77